### PR TITLE
Update Docker base image to Ubuntu Noble

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -27,7 +27,7 @@ jobs:
             CREATION_DATE=${{ env.NOW }}
           context: slurm/slurmctld
           load: true
-          tags: alphaunito/slurmctld:21.08.5
+          tags: alphaunito/slurmctld:23.11.4
       - name: "Build slurmd image"
         uses: docker/build-push-action@v5
         with:
@@ -36,7 +36,7 @@ jobs:
             CREATION_DATE=${{ env.NOW }}
           context: slurm/slurmd
           load: true
-          tags: alphaunito/slurmd:21.08.5
+          tags: alphaunito/slurmd:23.11.4
       - name: "Start Docker Compose"
         id: start-compose
         run: |
@@ -54,7 +54,7 @@ jobs:
               --project-name slurm            \
             exec                              \
               --user hpcuser                  \
-              slurmctld srun hostname
+              slurmctld srun -n 1 --deadline 00:01:00 hostname
       - name: "Show slurmctld logs on failure"
         if: ${{ always() && (steps.start-compose.outcome == 'failure' || steps.run-tests.outcome == 'failure') }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           context: slurm/slurmctld
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: alphaunito/slurmctld:21.08.5
+          tags: alphaunito/slurmctld:23.11.4
       - name: "Build slurmd image"
         uses: docker/build-push-action@v5
         with:
@@ -41,4 +41,4 @@ jobs:
           context: slurm/slurmd
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: alphaunito/slurmd:21.08.5
+          tags: alphaunito/slurmd:23.11.4

--- a/slurm/README.md
+++ b/slurm/README.md
@@ -1,11 +1,11 @@
 # Slurm on Docker
 
-This folder contains a fully Dockerized version of the [Slurm](https://slurm.schedmd.com/) queue manager. The version of SLURM shipped is the one downloaded from the apt repository, which is currently `21.08.5`
+This folder contains a fully Dockerized version of the [Slurm](https://slurm.schedmd.com/) queue manager. The version of SLURM shipped is the one downloaded from the apt repository, which is currently `23.11.4`
 
 This repository contains the source code of different container images:
 
-- `alphaunito/slurmctld:21.08.5`, which runs the Slurm control plane
-- `alphaunito/slurmd:21:08.5`, which runs a Slurm compute node
+- `alphaunito/slurmctld:23.11.4`, which runs the Slurm control plane
+- `alphaunito/slurmd:23.11.4`, which runs a Slurm compute node
 
 Plus, it also contains a [docker-compose.yml](./docker-compose.yml) file that can deplyo an entire Slurm cluster with a single controller and a set of compute nodes. All these components are detailed below
 
@@ -14,8 +14,8 @@ Plus, it also contains a [docker-compose.yml](./docker-compose.yml) file that ca
 The `slurmctld` process is the central management daemon of Slurm. It constitutes the control plane of the Slurm queue manager. The `slurmctld` Docker image can be build and published on DockerHub using the following commands
 
 ```bash
-docker build -t alphaunito/slurmctld:21.08.5 slurmctld
-docker push alphaunito/slurmctld:21.08.5
+docker build -t alphaunito/slurmctld:23.11.4 slurmctld
+docker push alphaunito/slurmctld:23.11.4
 ```
 
 To correctly populate the `slurm.conf` file, a `slurmctld` container needs 3 environment variables:
@@ -31,8 +31,8 @@ Note that all the compute nodes in the simulated HPC cluster should have a reach
 The `slurmd` process is the compute node daemon for Slurm. It monitors all tasks running on the compute node , accepts work (tasks), launches tasks, and kills running tasks upon request. The `slurmd` Docker image can be build and published using the following commands
 
 ```bash
-docker build -t alphaunito/slurmd:21.08.5 slurmd
-docker push alphaunito/slurmd:21.08.5
+docker build -t alphaunito/slurmd:23.11.4 slurmd
+docker push alphaunito/slurmd:23.11.4
 ```
 
 To correctly connect to a `slurmctld` node, a `slurmd` container needs a `SLURMCTLD_HOSTNAME` variable that should contain the hostname of the target `slurmctld` container. If this variable is not set, the container displays an error message and terminates

--- a/slurm/docker-compose.yml
+++ b/slurm/docker-compose.yml
@@ -1,7 +1,6 @@
-version: "3.8"
 services:
   slurmctld:
-    image: alphaunito/slurmctld:21.08.5
+    image: alphaunito/slurmctld:23.11.4
     environment:
       SLURMD_HOSTNAME_PREFIX: ${COMPOSE_PROJECT_NAME}-slurmd
       SLURMD_NODES: 2
@@ -13,7 +12,7 @@ services:
       - munge:/etc/munge
       - mysql:/var/lib/mysql
   slurmd:
-    image: alphaunito/slurmd:21.08.5
+    image: alphaunito/slurmd:23.11.4
     deploy:
       mode: replicated
       replicas: 2

--- a/slurm/slurmctld/Dockerfile
+++ b/slurm/slurmctld/Dockerfile
@@ -1,17 +1,17 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 ARG COMMIT="none"
 ARG CREATION_DATE="none"
 
 LABEL org.opencontainers.image.authors="Iacopo Colonnelli <iacopo.colonnelli@unito.it>"
-LABEL org.opencontainers.image.base.name="docker.io/ubuntu:jammy"
+LABEL org.opencontainers.image.base.name="docker.io/ubuntu:noble"
 LABEL org.opencontainers.image.created="${CREATION_DATE}"
 LABEL org.opencontainers.image.licenses="OpenSSL"
 LABEL org.opencontainers.image.revision="${COMMIT}"
 LABEL org.opencontainers.image.ref.name="alphaunito/slurmctld"
 LABEL org.opencontainers.image.source="https://github.com/alpha-unito/docker-for-hpc"
 LABEL org.opencontainers.image.title="Slurm management daemon"
-LABEL org.opencontainers.image.version="21.08.5"
+LABEL org.opencontainers.image.version="23.11.4"
 
 RUN apt update                                                                             \
  && apt install -y --no-install-recommends                                                 \
@@ -48,7 +48,7 @@ RUN apt update                                                                  
         --gecos ""                                                                         \
         hpcuser
 
-COPY config/cgroups.conf                                                                   \
+COPY config/cgroup.conf                                                                    \
      config/slurm.conf                                                                     \
      /etc/slurm/
 
@@ -65,4 +65,4 @@ EXPOSE 22 6817
 
 WORKDIR /home/hpcuser
 
-ENTRYPOINT supervisord
+ENTRYPOINT ["supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/slurm/slurmctld/config/cgroup.conf
+++ b/slurm/slurmctld/config/cgroup.conf
@@ -1,5 +1,4 @@
-CgroupAutomount=yes
-CgroupReleaseAgentDir="/etc/slurm/cgroup"
+CgroupPlugin=cgroup/v1
 ConstrainCores=yes
 ConstrainDevices=no
 ConstrainRAMSpace=yes

--- a/slurm/slurmctld/config/slurm.conf
+++ b/slurm/slurmctld/config/slurm.conf
@@ -12,7 +12,7 @@ PartitionName=docker Nodes=ALL Default=YES MaxTime=INFINITE State=UP
 ProctrackType=proctrack/linuxproc
 ReturnToService=1
 SchedulerType=sched/backfill
-SelectType=select/cons_res
+SelectType=select/cons_tres
 SelectTypeParameters=CR_Core
 SlurmctldDebug=info
 SlurmctldHost=__SLURMCTLD_HOST__

--- a/slurm/slurmctld/config/supervisord.conf
+++ b/slurm/slurmctld/config/supervisord.conf
@@ -2,6 +2,17 @@
 nodaemon=true
 logfile=/dev/null
 logfile_maxbytes=0
+user=root
+
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
 
 [program:munge]
 command=gosu munge /usr/sbin/munged --foreground

--- a/slurm/slurmd/Dockerfile
+++ b/slurm/slurmd/Dockerfile
@@ -1,17 +1,17 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 ARG COMMIT="none"
 ARG CREATION_DATE="none"
 
 LABEL org.opencontainers.image.authors="Iacopo Colonnelli <iacopo.colonnelli@unito.it>"
-LABEL org.opencontainers.image.base.name="docker.io/ubuntu:jammy"
+LABEL org.opencontainers.image.base.name="docker.io/ubuntu:noble"
 LABEL org.opencontainers.image.created="${CREATION_DATE}"
 LABEL org.opencontainers.image.licenses="OpenSSL"
 LABEL org.opencontainers.image.revision="${COMMIT}"
 LABEL org.opencontainers.image.ref.name="alphaunito/slurmd"
 LABEL org.opencontainers.image.source="https://github.com/alpha-unito/docker-for-hpc"
 LABEL org.opencontainers.image.title="Slurm compute node"
-LABEL org.opencontainers.image.version="21.08.5"
+LABEL org.opencontainers.image.version="23.11.4"
 
 RUN apt update                                                                             \
  && apt install -y --no-install-recommends                                                 \
@@ -50,9 +50,6 @@ RUN apt update                                                                  
         --gecos ""                                                                         \
         hpcuser
 
-COPY config/cgroups.conf                                                                   \
-     /etc/slurm/
-
 COPY config/supervisord.conf                                                               \
      /etc/supervisor/conf.d/
 
@@ -66,4 +63,4 @@ EXPOSE 22
 
 WORKDIR /home/hpcuser
 
-ENTRYPOINT supervisord
+ENTRYPOINT ["supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/slurm/slurmd/config/cgroups.conf
+++ b/slurm/slurmd/config/cgroups.conf
@@ -1,7 +1,0 @@
-CgroupAutomount=yes
-CgroupReleaseAgentDir="/etc/slurm/cgroup"
-ConstrainCores=yes
-ConstrainDevices=no
-ConstrainRAMSpace=yes
-ConstrainSwapSpace=yes
-IgnoreSystemd=yes

--- a/slurm/slurmd/config/supervisord.conf
+++ b/slurm/slurmd/config/supervisord.conf
@@ -2,6 +2,17 @@
 nodaemon=true
 logfile=/dev/null
 logfile_maxbytes=0
+user=root
+
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
 
 [program:munge]
 command=gosu munge /usr/sbin/munged --foreground


### PR DESCRIPTION
This commit updates the Docker base image used to build Slurm containers to the new Ubuntu Noble (24.04 LTS) version. Consequently, the Slurm version shipped with apt is updated to `v23.11.4`.