### PR TITLE
Add `flatuid` option

### DIFF
--- a/openpbs/server/scripts/run-openpbs
+++ b/openpbs/server/scripts/run-openpbs
@@ -30,6 +30,7 @@ sleep 3
 echo "Configure OpenPBS server"
 ${PBS_EXEC}/bin/qmgr -c "set server acl_roots+=root"
 ${PBS_EXEC}/bin/qmgr -c "set server acl_roots+=root@localhost"
+${PBS_EXEC}/bin/qmgr -c "set server flatuid=True"
 ${PBS_EXEC}/bin/qmgr -c "set server job_history_enable=True"
 ${PBS_EXEC}/bin/qmgr -c "set server job_history_duration=00:05:00"
 


### PR DESCRIPTION
This commit adds the `flatuid` config to the OpenPBS server to prevent `Bad UID for execution` errors.