### PR TITLE
Restore initial parameters

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -53,9 +53,8 @@ jobs:
               --file openpbs/docker-compose.yml \
               --project-name openpbs            \
             exec                                \
-              --user hpcuser                    \
               server                            \
-              sh -c "echo 'hostname' | qsub -q workq -u hpcuser -"
+              sh -c "echo 'hostname' | qsub -"
       - name: "Show OpenPBS server logs on failure"
         if: ${{ always() && (steps.start-compose.outcome == 'failure' || steps.run-tests.outcome == 'failure') }}
         run: |

--- a/openpbs/server/scripts/run-openpbs
+++ b/openpbs/server/scripts/run-openpbs
@@ -28,8 +28,9 @@ sh -c "${PBS_EXEC}/sbin/pbs_server -N" &
 sleep 3
 
 echo "Configure OpenPBS server"
-${PBS_EXEC}/bin/qmgr -c "set server job_history_enable=True"
-${PBS_EXEC}/bin/qmgr -c "set server job_history_duration=00:05:00"
+${PBS_EXEC}/bin/qmgr -c "set server acl_roots = root"
+${PBS_EXEC}/bin/qmgr -c "set server job_history_enable = True"
+${PBS_EXEC}/bin/qmgr -c "set server job_history_duration = 00:05:00"
 
 echo "Configure OpenPBS scheduler"
 ${PBS_EXEC}/bin/qmgr -c "set sched sched_host = localhost"


### PR DESCRIPTION
The `Bad UID for execution` is apparently unsolvable within the current OpenPBS version. Therefore, this commit disables all the fixes attempted to overcome the issue.