### PR TITLE
Fix names of execution nodes

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -54,7 +54,7 @@ jobs:
               --project-name openpbs            \
             exec                                \
               server                            \
-              sh -c "echo 'hostname' | qsub -"
+              sh -c "echo 'hostname' | qsub -l 'nodes=2:ppn=1' -"
       - name: "Show OpenPBS server logs on failure"
         if: ${{ always() && (steps.start-compose.outcome == 'failure' || steps.run-tests.outcome == 'failure') }}
         run: |

--- a/openpbs/server/scripts/run-openpbs
+++ b/openpbs/server/scripts/run-openpbs
@@ -35,7 +35,7 @@ ${PBS_EXEC}/bin/qmgr -c "set server job_history_duration = 00:05:00"
 echo "Configure OpenPBS scheduler"
 ${PBS_EXEC}/bin/qmgr -c "set sched sched_host = localhost"
 
-for NODE in $(seq 1 ${PBS_EXECUTION_NODES}); do
+for NODE in $(seq 0 $((PBS_EXECUTION_NODES-1))); do
     echo "Create node ${PBS_EXECUTION_HOST_NAME_PREFIX}-${NODE}"
     ${PBS_EXEC}/bin/qmgr -c "create node ${PBS_EXECUTION_HOST_NAME_PREFIX}-${NODE} queue=workq"
 done


### PR DESCRIPTION
This commit correctly list PBS execution servers from 0 to N-1, instead of naming them form 1 to N. It also adds a test to avoid regressions.